### PR TITLE
Indicate that diff --all is mutually exclusive from -i and -x

### DIFF
--- a/packages/cli/src/commands/diff.js
+++ b/packages/cli/src/commands/diff.js
@@ -61,7 +61,8 @@ export const builder = yargs =>
     all: {
       description: 'Include everything in diff',
       group: GROUPS.FILTER,
-      type: 'boolean'
+      type: 'boolean',
+      conflicts: ['i', 'x']
     },
     ...getOptions(OPTIONS.OUTPUT, {sourceType: 'object'}),
     ...OPTIONS.JSON_TRANSFORM,


### PR DESCRIPTION
Closes https://github.com/IBM/report-toolkit/issues/71

Tested by building and running diff with the conflicting options, and you get `Arguments all and x are mutually exclusive`