### PR TITLE
search in alternate dirs for config; closes #83

### DIFF
--- a/.rtkrc.js
+++ b/.rtkrc.js
@@ -1,5 +1,5 @@
 exports.config = [
-  'report-toolkit:recommended',
+  'rtk:recommended',
   {
     rules: {
       'long-timeout': ['on', {timeout: 5000}]

--- a/packages/cli/test/e2e/cli-helper.js
+++ b/packages/cli/test/e2e/cli-helper.js
@@ -1,4 +1,4 @@
-import {createDebugger} from '@report-toolkit/common';
+import {createDebugger, _} from '@report-toolkit/common';
 import csv from 'csvtojson';
 import execa from 'execa';
 
@@ -16,13 +16,20 @@ export const run = async (...flags) => runWithOptions(flags);
 
 /**
  * Run executable with command, flags, etc., but use `json` as final executable,
- * and parse the result into a JS object. Should be used with a command that we
- * expect NOT to exit with a nonzero code.
- * @param  {...string} flags - Flags
+ * and parse the result into a JS object. The command itself will NOT; any
+ * nonzero exit will be caught and resolved.  If JSON parsing fails, only then will we get a rejection.
+ * @param {string[]|string} flags - Any flags to pass to the executable
+ * @param {execa.Options} opts - Options for execa
  * @returns {Promise<any>} Result of `JSON.parse()`
  */
-export const runAsJSON = async (...flags) => {
-  const result = await run(...flags, '-t', 'json');
+export const runAsJSON = async (flags, opts = {}) => {
+  flags = [..._.castArray(flags), '-t', 'json'];
+  let result;
+  try {
+    result = await runWithOptions(flags, opts);
+  } catch (res) {
+    result = res;
+  }
   debug(`converting result of ${result.command} from JSON`);
   return JSON.parse(result.stdout);
 };

--- a/packages/cli/test/e2e/inspect.spec.js
+++ b/packages/cli/test/e2e/inspect.spec.js
@@ -1,7 +1,6 @@
-import {_} from '@report-toolkit/common';
 import {tmpdir} from 'os';
 
-import {run, runWithOptions} from './cli-helper.js';
+import {run, runAsJSON} from './cli-helper.js';
 
 const REPORT_002_FILEPATH = require.resolve(
   '@report-toolkit/common/test/fixture/reports/report-002-library-mismatch.json'
@@ -19,9 +18,9 @@ describe('@report-toolkit/cli:command:inspect', function() {
   describe('when it cannot find a config file', function() {
     it('should enable all rules', function() {
       return expect(
-        runWithOptions(['inspect', REPORT_002_FILEPATH, '-t', 'json'], {
+        runAsJSON(['inspect', REPORT_002_FILEPATH], {
           cwd: tmpdir()
-        }).catch(_.pipe(_.get('stdout'), JSON.parse)),
+        }),
         'when fulfilled',
         'to have items satisfying',
         {

--- a/packages/cli/test/e2e/transform.spec.js
+++ b/packages/cli/test/e2e/transform.spec.js
@@ -40,7 +40,7 @@ describe('@report-toolkit/cli:command:transform', function() {
     it('should succeed', function() {
       return expect(
         // filters contrived, as -i header.release.name would work
-        runAsJSON(
+        runAsJSON([
           'transform',
           REPORT_005_FILEPATH,
           '-t',
@@ -51,7 +51,7 @@ describe('@report-toolkit/cli:command:transform', function() {
           'header.release.headersUrl',
           '-x',
           'header.release.sourceUrl'
-        ),
+        ]),
         'to be fulfilled with',
         {
           header: {

--- a/packages/common/test/fixture/config/.rtkrc.js
+++ b/packages/common/test/fixture/config/.rtkrc.js
@@ -1,5 +1,5 @@
 exports.config = [
-  'report-toolkit:recommended',
+  'rtk:recommended',
   {
     name: 'DEFAULT',
     rules: {

--- a/packages/common/test/fixture/config/custom.config.js
+++ b/packages/common/test/fixture/config/custom.config.js
@@ -1,5 +1,5 @@
 exports.config = [
-  'report-toolkit:recommended',
+  'rtk:recommended',
   {
     name: 'CUSTOM',
     rules: {

--- a/packages/config/src/configs/recommended.js
+++ b/packages/config/src/configs/recommended.js
@@ -1,5 +1,5 @@
 export const config = {
-  name: 'recommended',
+  name: 'rtk:recommended',
   rules: {
     'cpu-usage': 'on',
     'library-mismatch': 'on',

--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -1,6 +1,5 @@
 import {
   _,
-  constants,
   createDebugger,
   error,
   observable,
@@ -9,7 +8,6 @@ import {
 
 import {config as recommended} from './configs/recommended.js';
 
-const {NAMESPACE} = constants;
 const {map} = observable;
 const {kFlattenedConfig} = symbols;
 const debug = createDebugger('config');
@@ -36,7 +34,10 @@ const normalizeBooleans = obj =>
     }
   });
 
-const pushToConfigList = list => value =>
+/**
+ * @param {object[]} list
+ */
+const pushToConfigList = list => /** @param {object} value */ value =>
   list.push(normalizeBooleans(_.omit('name', value)));
 
 /**
@@ -96,9 +97,11 @@ const flattenConfig = (config, configObjects = []) => {
   return retval;
 };
 
+export const RECOMMENDED_CONFIG_NAME = recommended.name;
+
 // XXX: move this
 export const BUILTIN_CONFIGS = new Map([
-  [`${NAMESPACE}:${recommended.name}`, recommended]
+  [RECOMMENDED_CONFIG_NAME, recommended]
 ]);
 
 export const filterEnabledRules = _.pipe(

--- a/packages/fs/package-lock.json
+++ b/packages/fs/package-lock.json
@@ -57,6 +57,14 @@
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
+		"global-dirs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
+			"integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+			"requires": {
+				"ini": "^1.3.5"
+			}
+		},
 		"import-fresh": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -65,6 +73,11 @@
 				"caller-path": "^2.0.0",
 				"resolve-from": "^3.0.0"
 			}
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -108,6 +121,11 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"xdg-basedir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
 		}
 	}
 }

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -5,7 +5,9 @@
   "author": "Christopher Hiller <christopher.hiller@ibm.com> (https://boneskull.com/)",
   "dependencies": {
     "@report-toolkit/common": "^0.5.1",
-    "cosmiconfig": "^5.2.1"
+    "cosmiconfig": "^5.2.1",
+    "global-dirs": "^2.0.1",
+    "xdg-basedir": "^4.0.0"
   },
   "engines": {
     "node": ">=10"

--- a/packages/fs/src/fs-config-loader.js
+++ b/packages/fs/src/fs-config-loader.js
@@ -10,7 +10,6 @@ import {RC_NAMESPACE} from './constants.js';
 const {RTKERR_MISSING_CONFIG} = error;
 const {
   map,
-  mapTo,
   mergeMap,
   filter,
   concatMap,
@@ -110,7 +109,6 @@ export const fromFilesystemToConfig = ({
           `No config file found at ${rawConfigOrFilepath}`
         )
       )
-    ),
-    pipeIf(_.isEmpty, mapTo({}))
+    )
   );
 };

--- a/packages/fs/src/fs-config-loader.js
+++ b/packages/fs/src/fs-config-loader.js
@@ -1,5 +1,9 @@
 import {_, createDebugPipe, error, observable} from '@report-toolkit/common';
+import path from 'path';
 import cosmiconfig from 'cosmiconfig';
+import xdgBasedir from 'xdg-basedir';
+import globalDirs from 'global-dirs';
+import os from 'os';
 
 import {RC_NAMESPACE} from './constants.js';
 
@@ -8,13 +12,25 @@ const {
   map,
   mapTo,
   mergeMap,
+  filter,
+  concatMap,
+  concatMapTo,
   of,
   pipeIf,
   switchMapTo,
+  take,
   throwRTkError
 } = observable;
 
 const debug = createDebugPipe('cli', 'loaders', 'config');
+
+const EXTRA_SEARCH_DIRS = [
+  os.homedir(),
+  path.join(globalDirs.npm.prefix, 'etc')
+];
+if (os.platform() !== 'win32') {
+  EXTRA_SEARCH_DIRS.push(...xdgBasedir.configDirs, '/etc');
+}
 
 const getExplorer = _.memoize(opts =>
   cosmiconfig(
@@ -29,7 +45,12 @@ const getExplorer = _.memoize(opts =>
   )
 );
 
-const toConfigFromSearchPath = (opts = {}) => {
+/**
+ *
+ * @param {cosmiconfig.ExplorerOptions} [opts] - Extra opts for cosmiconfig
+ * @returns {import('rxjs').OperatorFunction<string,object>}
+ */
+function toConfigFromSearchPath(opts = {}) {
   const explorer = getExplorer(opts);
   return observable =>
     observable.pipe(
@@ -40,34 +61,46 @@ const toConfigFromSearchPath = (opts = {}) => {
         map(_.get('config.config'))
       )
     );
-};
+}
 
 /**
  *
  * @param {cosmiconfig.ExplorerOptions} [opts] - Extra opts for cosmiconfig
  * @returns {import('rxjs').OperatorFunction<string,object>}
  */
-const toConfigFromFilepath = (opts = {}) => {
+function toConfigFromFilepath(opts = {}) {
   const explorer = getExplorer(opts);
   return observable =>
     observable.pipe(
       mergeMap(filepath => explorer.load(filepath)),
       map(_.get('config.config'))
     );
-};
+}
 
 export const fromFilesystemToConfig = ({
   config: rawConfigOrFilepath = {},
   searchPath = process.cwd(),
   search = true
-} = {}) =>
-  of(rawConfigOrFilepath).pipe(
+} = {}) => {
+  const allSearchPaths = [searchPath, ...EXTRA_SEARCH_DIRS];
+  return of(rawConfigOrFilepath).pipe(
     pipeIf(_.isString, toConfigFromFilepath()),
     pipeIf(
-      rawConfig => _.isEmpty(rawConfig) && search,
-      debug(() => `searching in ${searchPath} for config`),
-      mapTo(searchPath),
-      toConfigFromSearchPath()
+      /** @param {object} rawConfig */ rawConfig =>
+        _.isEmpty(rawConfig) && search,
+      concatMapTo(allSearchPaths),
+      debug(allSearchPath => `searching in ${allSearchPath} for config`),
+      concatMap(allSearchPath =>
+        of(allSearchPath).pipe(
+          pipeIf(allSearchPath === searchPath, toConfigFromSearchPath()),
+          pipeIf(
+            allSearchPath !== searchPath,
+            toConfigFromSearchPath({stopDir: allSearchPath})
+          )
+        )
+      ),
+      filter(_.negate(_.isEmpty)),
+      take(1)
     ),
     pipeIf(
       _.isEmpty && _.isString(rawConfigOrFilepath),
@@ -80,3 +113,4 @@ export const fromFilesystemToConfig = ({
     ),
     pipeIf(_.isEmpty, mapTo({}))
   );
+};

--- a/packages/fs/test/fs-config-loader.spec.js
+++ b/packages/fs/test/fs-config-loader.spec.js
@@ -2,7 +2,7 @@ import customConfig from '@report-toolkit/common/test/fixture/config/custom.conf
 import {join} from 'path';
 
 const defaultConfig = [
-  'report-toolkit:recommended',
+  'rtk:recommended',
   {
     rules: {
       'long-timeout': ['on', {timeout: 5000}]
@@ -11,7 +11,7 @@ const defaultConfig = [
 ];
 
 const etcConfig = [
-  'report-toolkit:recommended',
+  'rtk:recommended',
   {
     rules: {
       'long-timeout': ['on', {timeout: 1000}]

--- a/packages/inspector/src/rule-config.js
+++ b/packages/inspector/src/rule-config.js
@@ -19,7 +19,9 @@ export class RuleConfig {
       rawConfig = {};
     }
 
-    debug(`found raw config %O`, rawConfig);
+    if (!_.isEmpty(rawConfig)) {
+      debug('found raw config %O', rawConfig);
+    }
 
     this.config = this.validate(rawConfig);
   }


### PR DESCRIPTION
This will additionally search for an `.rtkrc.js` or `rtk.config.js` in
`$HOME`, `$(npm prefix)/etc`, and if on POSIX OS, XDG config dir(s) and
`/etc`, in that order.

I note that it's not particularly ergonomic to do this using
`cosmiconfig`'s API.