### PR TITLE
fix: json-ptr version compatibility

### DIFF
--- a/packages/diff/src/index.js
+++ b/packages/diff/src/index.js
@@ -1,5 +1,5 @@
 import {_, constants, createDebugger, observable} from '@report-toolkit/common';
-import ptr from 'json-ptr';
+import {JsonPointer} from 'json-ptr';
 import {createPatch} from 'rfc6902';
 const {Observable, filter, mergeMap, pipeIf, map} = observable;
 
@@ -75,7 +75,7 @@ export function diff(opts = {}) {
                   const nextPathParts = patchObj.path.split('/');
                   const nextPathIdx = Number(nextPathParts.pop()) + offset;
                   const nextPath = nextPathParts.concat(nextPathIdx).join('/');
-                  oldValue = ptr.get(reportA, nextPath);
+                  oldValue = JsonPointer.get(reportA, nextPath);
                   offset++;
                   nextValue = {...patchObj, oldValue, path: nextPath};
                 } else {
@@ -83,7 +83,7 @@ export function diff(opts = {}) {
                   if (patchObj.op === 'add') {
                     nextValue = patchObj;
                   } else {
-                    oldValue = ptr.get(reportA, patchObj.path);
+                    oldValue = JsonPointer.get(reportA, patchObj.path);
                     nextValue = {...patchObj, oldValue};
                   }
                   offset = 1;


### PR DESCRIPTION
- Node.js v12.19.0
- report-toolkit v0.6.0

```sh
npm i -g report-toolkit
rtk diff report1.json report2.json

/Test/node/lib/node_modules/report-toolkit/node_modules/rxjs/internal/util/hostReportError.js:4
    setTimeout(function () { throw err; }, 0);
                             ^

TypeError: ptr.get is not a function
    at /Test/node/lib/node_modules/report-toolkit/node_modules/@report-toolkit/diff/dist/report-toolkit-diff.cjs.js:90:28
    at /Test/node/lib/node_modules/report-toolkit/node_modules/lodash/fp/_baseConvert.js:34:28
    at arrayEach (/Test/node/lib/node_modules/report-toolkit/node_modules/lodash/_arrayEach.js:15:9)
    at forEach (/Test/node/lib/node_modules/report-toolkit/node_modules/lodash/forEach.js:38:10)
    at wrapper (/Test/node/lib/node_modules/report-toolkit/node_modules/lodash/_createHybrid.js:87:15)
    at Object.<anonymous> (/Test/node/lib/node_modules/report-toolkit/node_modules/lodash/fp/_baseConvert.js:455:19)
    at apply (/Test/node/lib/node_modules/report-toolkit/node_modules/lodash/_apply.js:15:25)
    at Object.wrapper [as forEach] (/Test/node/lib/node_modules/report-toolkit/node_modules/lodash/_createCurry.js:41:12)
    at Observable._subscribe (/Test/node/lib/node_modules/report-toolkit/node_modules/@report-toolkit/diff/dist/report-toolkit-diff.cjs.js:63:16)
    at Observable._trySubscribe (/Test/node/lib/node_modules/report-toolkit/node_modules/rxjs/internal/Observable.js:44:25)
```

The reason I am getting the above error is because the `json-ptr` version is installed as v1.3.2 when installing the module.
The export has changed in `json-ptr` v1.3.0
> https://github.com/flitbit/json-ptr#releases
> In version v1.3.0 of the library, global functions were moved to static functions of the JsonPointer class. There should be no difference in arguments or behavior. If you were previously importing the global functions it is a small change to destructure them and have compatible code.

This PR is a fix that maintains compatibility with `json-ptr` v1.2.0 and v1.3.2
Passed `npm test` in both versions.
