### PR TITLE
fix(core): rules do not run when told not to run; closes #102

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16477,51 +16477,13 @@
       }
     },
     "typedoc-plugin-markdown": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.4.2.tgz",
-      "integrity": "sha512-BBH+9/Uq5XbsqfzCDl8Jq4iaLXRMXRuAHZRFarAZX7df8+F3vUjDx/WHWoWqbZ/XUFzduLC2Iuy2qwsJX8SQ7A==",
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.2.17.tgz",
+      "integrity": "sha512-eE6cTeqsZIbjur6RG91Lhx1vTwjR49OHwVPRlmsxY3dthS4FNRL8sHxT5Y9pkosBwv1kSmNGQEPHjMYy1Ag6DQ==",
       "dev": true,
       "requires": {
-        "fs-extra": "^9.0.1",
-        "handlebars": "^4.7.6"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true
-        }
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.3"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sync-monorepo-packages": "^0.3.2",
     "syncpack": "^5.6.10",
     "typedoc": "^0.16.11",
-    "typedoc-plugin-markdown": "^2.4.2",
+    "typedoc-plugin-markdown": "2.2.17",
     "typescript": "^3.9.7",
     "unexpected": "^11.15.1",
     "unexpected-rxjs": "^0.2.4",

--- a/packages/core/src/observable.js
+++ b/packages/core/src/observable.js
@@ -119,29 +119,6 @@ function toReport(opts = {}) {
 
 /**
  *
- * @param {object} [config] - Raw rule configuration
- * @returns {import('rxjs').OperatorFunction<import('@report-toolkit/inspector/src/rule').RuleDefinition,import('@report-toolkit/inspector/src/rule-config').RuleConfig>}
- */
-function toRuleConfig(config = {}) {
-  const ruleIdsCount = _.getOr(0, 'rules.length', config);
-  return ruleDefs =>
-    ruleDefs.pipe(
-      pipeIf(
-        !ruleIdsCount,
-        debug(() => 'enabling all rules by default')
-      ),
-      pipeIf(
-        ruleIdsCount,
-        filter(({id}) => Boolean(_.get(id, config.rules)))
-      ),
-      map(ruleDefinition =>
-        inspector.createRule(ruleDefinition).toRuleConfig(config)
-      )
-    );
-}
-
-/**
- *
  * @param {Partial<DiffOptions>} [opts]
  * @returns {import('rxjs').OperatorFunction<import('@report-toolkit/common/src/report').Report[],object>}
  */
@@ -160,6 +137,30 @@ function toReportDiff(opts = {}) {
         }
       }),
       diffReports(opts)
+    );
+}
+
+/**
+ *
+ * @param {object} [config] - Raw rule configuration
+ * @hidden
+ * @returns {import('rxjs').OperatorFunction<import('@report-toolkit/inspector/src/rule').RuleDefinition,import('@report-toolkit/inspector/src/rule-config').RuleConfig>}
+ */
+export function toRuleConfig(config = {}) {
+  const hasEnabledRules = _.some(Boolean, config.rules || {});
+  return ruleDefs =>
+    ruleDefs.pipe(
+      pipeIf(
+        !hasEnabledRules,
+        debug(() => 'enabling all rules by default')
+      ),
+      pipeIf(
+        hasEnabledRules,
+        filter(({id}) => Boolean(_.get(id, config.rules)))
+      ),
+      map(ruleDefinition =>
+        inspector.createRule(ruleDefinition).toRuleConfig(config)
+      )
     );
 }
 

--- a/packages/inspector/src/message.js
+++ b/packages/inspector/src/message.js
@@ -84,10 +84,14 @@ export const createMessage = (message, opts = {}) => {
  * @property {boolean} isAggregate - `true` if {@link Message} references multiple files
  * @property {Error} error - If present, an `Error` which was thrown by the Rule
  * @property {object} config - Rule configuration
- * @property {import('@report-toolkit/common/src/constants').ERROR|import('@report-toolkit/common/src/constants').WARNING|import('@report-toolkit/common/src/constants').INFO} severity - The severity of the {@link Message}
+ * @property {constants.ERROR|constants.WARNING|constants.INFO} severity - The severity of the {@link Message}
  * @property {string} message - The message text itself, if first param not passed to {@link Message.createMessage}.
  */
 
 /**
  * @typedef {string|Partial<MessageOptions>} RawMessage
+ */
+
+/**
+ * @typedef {import('@report-toolkit/common/src/constants')} constants
  */

--- a/packages/transformers/src/index.js
+++ b/packages/transformers/src/index.js
@@ -75,7 +75,7 @@ export const isKnownTransformer = id => Boolean(transformerModules[id]);
 export {Transformer};
 
 /**
- * @returns {OperatorFunction<TransformerConfig,Transformer>}
+ * @returns {OperatorFunction<TransformerConfig,Transformer<any,any>>}
  */
 export const toTransformer = () => observable =>
   observable.pipe(
@@ -91,7 +91,7 @@ export const toTransformer = () => observable =>
 /**
  *
  * @param {Partial<TransformOptions>} [opts]
- * @returns {OperatorFunction<Transformer,Transformer>}
+ * @returns {OperatorFunction<Transformer<any,any>,Transformer<any,any>>}
  */
 export const validateTransformerChain = ({
   beginWith = 'report',
@@ -148,7 +148,7 @@ export const validateTransformerChain = ({
  * @param {Observable<any>} source
  */
 export const runTransformer = source => /**
- * @param {Observable<Transformer>} observable
+ * @param {Observable<Transformer<any,any>>} observable
  */ observable =>
   observable.pipe(
     toArray(),

--- a/packages/transformers/src/transformer.js
+++ b/packages/transformers/src/transformer.js
@@ -66,8 +66,8 @@ class Transformer {
 
   /**
    * Pipe one Transformer to another
-   * @param {Transformer} transformer
-   * @returns {Transformer}
+   * @param {Transformer<any,any>} transformer
+   * @returns {Transformer<any,any>}
    */
   pipe(transformer) {
     if (!this.canPipeTo(transformer)) {
@@ -90,8 +90,8 @@ class Transformer {
 
   /**
    *
-   * @param {Transformer} transformer
-   * @returns {Transformer}
+   * @param {Transformer<any,any>} transformer
+   * @returns {Transformer<any,any>}
    */
   pipeFrom(transformer) {
     this._source = transformer;
@@ -100,7 +100,7 @@ class Transformer {
 
   /**
    * Returns `true` if this Transformer can pipe to another
-   * @param {Transformer} transformer - Transformer to compare
+   * @param {Transformer<any,any>} transformer - Transformer to compare
    */
   canPipeTo(transformer) {
     return _.includes(this.output, transformer.input);
@@ -182,5 +182,10 @@ export const createTransformer = Transformer.create;
 
 /**
  * @template T,U
- * @typedef {(opts?: object)=>import('rxjs/internal/types').OperatorFunction<T,U>} TransformFunction
+ * @typedef {import('rxjs/internal/types').OperatorFunction<T,U>} OperatorFunction<T,U>
+ */
+
+/**
+ * @template T,U
+ * @typedef {(opts?: object)=>OperatorFunction<T,U>} TransformFunction
  */

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -12,10 +12,10 @@
     "packages/inspector/src/rule.d.ts",
     "packages/inspector/src/rule-config.d.ts",
     "packages/inspector/src/message.d.ts",
-    "packages/transformers/src/index.d.ts"
   ],
   "typedocOptions": {
     "exclude": [
+      "packages/common/diagnostic-report.d.ts",
       "packages/common/src/error*",
       "packages/common/src/debug*",
       "packages/common/src/index*",
@@ -23,7 +23,7 @@
       "packages/common/src/redact*",
       "packages/common/src/symbols*",
       "packages/common/src/util*",
-      "packages/diff,cli,fs,report-toolkit,config}/src/**/*",
+      "packages/diff,cli,fs,report-toolkit,config,transformers}/src/**/*",
       "packages/inspector/src/rules/*",
       "packages/inspector/src/ajv*",
       "packages/inspector/src/index*",


### PR DESCRIPTION
This ensures the `toRuleConfig()` function in core treats the `rules` prop of an `.rtkrc.js` file as an _object_ instead of an array.
